### PR TITLE
fix contact us send button #121

### DIFF
--- a/content/contact/index.md
+++ b/content/contact/index.md
@@ -22,12 +22,10 @@ sections:
     
       # Email form provider
       form:
-        provider: netlify
+        provider: formspree
         formspree:
-          id:
-        netlify:
-          # Enable CAPTCHA challenge to reduce spam?
-          captcha: false
+          id: xnnebrev # ← real Formspree from link: https://formspree.io/f/xnnebrev
+
     design:
       columns: '1'
 


### PR DESCRIPTION
Fix the 'Send' button in the Contact Us page by creating a new form from a free account (50 form submissions allowed per month) from `the Formspree website`, and using it instead of Netlift. This separate third-party form is required as we are hosting on GitHub Pages and not on Netlify.

Also, tested the functioning of the form in the local build. Test was successful.